### PR TITLE
feat: Django Admin 카테고리별 분류 및 모델 업데이트

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
   # PostgreSQL 데이터베이스 서비스
   db:
     image: postgres:18 # PostgreSQL 18 이미지 사용
+    ports:
+      - "5433:5432"  # 외부포트:5433, 내부포트:5432 (로컬 PostgreSQL과 충돌 방지)
     volumes:
       - postgres_data:/var/lib/postgresql # PostgreSQL 18+는 /var/lib/postgresql에 마운트
     environment:

--- a/music/admin.py
+++ b/music/admin.py
@@ -1,45 +1,231 @@
 from django.contrib import admin
-from .models import Music, Artists, Albums, Tags, MusicTags, Users
+from .models import (
+    Music, Artists, Albums, Genres, Tags, MusicTags,
+    Playlists, PlaylistItems, PlaylistLikes,
+    Users, UsersGenre,
+    PlayLogs, MusicLikes, Charts,
+    AiInfo
+)
 
+
+# ===== 🎵 MUSIC 섹션 =====
 
 @admin.register(Music)
 class MusicAdmin(admin.ModelAdmin):
-    list_display = ('music_id', 'music_name', 'artist', 'album', 'genre', 'duration', 'is_ai', 'created_at')
-    list_filter = ('genre', 'is_ai', 'is_deleted')
-    search_fields = ('music_name', 'artist__artist_name', 'album__album_name')
-    list_per_page = 50
+    list_display = ('music_id', 'music_name', 'get_artist_name', 'get_album_name', 'genre', 'duration_display', 'is_ai', 'created_at')
+    list_filter = ('is_ai', 'is_deleted', 'created_at')
+    search_fields = ('music_name', 'artist__artist_name', 'album__album_name', 'genre')
+    list_per_page = 100
+    ordering = ('-created_at',)
+    
+    def get_artist_name(self, obj):
+        return obj.artist.artist_name if obj.artist else '-'
+    get_artist_name.short_description = '아티스트'
+    
+    def get_album_name(self, obj):
+        return obj.album.album_name if obj.album else '-'
+    get_album_name.short_description = '앨범'
+    
+    def duration_display(self, obj):
+        if obj.duration:
+            minutes = obj.duration // 60
+            seconds = obj.duration % 60
+            return f"{minutes}:{seconds:02d}"
+        return '-'
+    duration_display.short_description = '재생시간'
 
 
 @admin.register(Artists)
 class ArtistsAdmin(admin.ModelAdmin):
-    list_display = ('artist_id', 'artist_name', 'created_at', 'is_deleted')
+    list_display = ('artist_id', 'artist_name', 'get_music_count', 'created_at', 'is_deleted')
     search_fields = ('artist_name',)
-    list_filter = ('is_deleted',)
-    list_per_page = 50
+    list_filter = ('is_deleted', 'created_at')
+    list_per_page = 100
+    
+    def get_music_count(self, obj):
+        return obj.music_set.count()
+    get_music_count.short_description = '곡 수'
 
 
 @admin.register(Albums)
 class AlbumsAdmin(admin.ModelAdmin):
-    list_display = ('album_id', 'album_name', 'artist', 'created_at', 'is_deleted')
+    list_display = ('album_id', 'album_name', 'get_artist_name', 'created_at', 'is_deleted')
     search_fields = ('album_name', 'artist__artist_name')
+    list_filter = ('is_deleted', 'created_at')
+    list_per_page = 100
+    
+    def get_artist_name(self, obj):
+        return obj.artist.artist_name if obj.artist else '-'
+    get_artist_name.short_description = '아티스트'
+
+
+@admin.register(Genres)
+class GenresAdmin(admin.ModelAdmin):
+    list_display = ('genre_id', 'genre_name', 'created_at', 'is_deleted')
+    search_fields = ('genre_name',)
     list_filter = ('is_deleted',)
     list_per_page = 50
 
 
 @admin.register(Tags)
 class TagsAdmin(admin.ModelAdmin):
-    list_display = ('tag_id', 'tag_key', 'created_at')
+    list_display = ('tag_id', 'tag_key', 'created_at', 'is_deleted')
     search_fields = ('tag_key',)
+    list_filter = ('is_deleted',)
+    list_per_page = 50
 
 
 @admin.register(MusicTags)
 class MusicTagsAdmin(admin.ModelAdmin):
-    list_display = ('music', 'tag', 'created_at')
+    list_display = ('get_music_name', 'get_tag_name', 'created_at')
     search_fields = ('music__music_name', 'tag__tag_key')
+    list_per_page = 100
+    
+    def get_music_name(self, obj):
+        return obj.music.music_name if obj.music else '-'
+    get_music_name.short_description = '음악'
+    
+    def get_tag_name(self, obj):
+        return obj.tag.tag_key if obj.tag else '-'
+    get_tag_name.short_description = '태그'
 
+
+# ===== 📝 PLAYLIST 섹션 =====
+
+@admin.register(Playlists)
+class PlaylistsAdmin(admin.ModelAdmin):
+    list_display = ('playlist_id', 'title', 'get_user_nickname', 'visibility', 'created_at', 'is_deleted')
+    search_fields = ('title', 'user__nickname')
+    list_filter = ('visibility', 'is_deleted', 'created_at')
+    list_per_page = 50
+    
+    def get_user_nickname(self, obj):
+        return obj.user.nickname if obj.user else '-'
+    get_user_nickname.short_description = '생성자'
+
+
+@admin.register(PlaylistItems)
+class PlaylistItemsAdmin(admin.ModelAdmin):
+    list_display = ('item_id', 'get_playlist_title', 'get_music_name', 'order', 'created_at')
+    search_fields = ('playlist__title', 'music__music_name')
+    list_per_page = 50
+    
+    def get_playlist_title(self, obj):
+        return obj.playlist.title if obj.playlist else '-'
+    get_playlist_title.short_description = '플레이리스트'
+    
+    def get_music_name(self, obj):
+        return obj.music.music_name if obj.music else '-'
+    get_music_name.short_description = '음악'
+
+
+@admin.register(PlaylistLikes)
+class PlaylistLikesAdmin(admin.ModelAdmin):
+    list_display = ('like_id', 'get_playlist_title', 'get_user_nickname', 'created_at')
+    search_fields = ('playlist__title', 'user__nickname')
+    list_per_page = 50
+    
+    def get_playlist_title(self, obj):
+        return obj.playlist.title if obj.playlist else '-'
+    get_playlist_title.short_description = '플레이리스트'
+    
+    def get_user_nickname(self, obj):
+        return obj.user.nickname if obj.user else '-'
+    get_user_nickname.short_description = '사용자'
+
+
+# ===== 👤 USER 섹션 =====
 
 @admin.register(Users)
 class UsersAdmin(admin.ModelAdmin):
     list_display = ('user_id', 'nickname', 'email', 'created_at', 'is_deleted')
     search_fields = ('nickname', 'email')
-    list_filter = ('is_deleted',)
+    list_filter = ('is_deleted', 'created_at')
+    list_per_page = 50
+
+
+@admin.register(UsersGenre)
+class UsersGenreAdmin(admin.ModelAdmin):
+    list_display = ('get_user_id', 'get_user_nickname', 'get_genre_name', 'created_at')
+    search_fields = ('user__nickname', 'genre__genre_name')
+    list_per_page = 50
+    
+    def get_user_id(self, obj):
+        return obj.user.user_id if obj.user else '-'
+    get_user_id.short_description = 'User ID'
+    
+    def get_user_nickname(self, obj):
+        return obj.user.nickname if obj.user else '-'
+    get_user_nickname.short_description = '사용자'
+    
+    def get_genre_name(self, obj):
+        return obj.genre.genre_name if obj.genre else '-'
+    get_genre_name.short_description = '선호 장르'
+
+
+# ===== 📊 ANALYTICS 섹션 =====
+
+@admin.register(PlayLogs)
+class PlayLogsAdmin(admin.ModelAdmin):
+    list_display = ('play_log_id', 'get_user_nickname', 'get_music_name', 'played_at')
+    search_fields = ('user__nickname', 'music__music_name')
+    list_filter = ('played_at',)
+    list_per_page = 100
+    ordering = ('-played_at',)
+    
+    def get_user_nickname(self, obj):
+        return obj.user.nickname if obj.user else '-'
+    get_user_nickname.short_description = '사용자'
+    
+    def get_music_name(self, obj):
+        return obj.music.music_name if obj.music else '-'
+    get_music_name.short_description = '음악'
+
+
+@admin.register(MusicLikes)
+class MusicLikesAdmin(admin.ModelAdmin):
+    list_display = ('like_id', 'get_user_nickname', 'get_music_name', 'created_at')
+    search_fields = ('user__nickname', 'music__music_name')
+    list_filter = ('created_at',)
+    list_per_page = 100
+    
+    def get_user_nickname(self, obj):
+        return obj.user.nickname if obj.user else '-'
+    get_user_nickname.short_description = '사용자'
+    
+    def get_music_name(self, obj):
+        return obj.music.music_name if obj.music else '-'
+    get_music_name.short_description = '음악'
+
+
+@admin.register(Charts)
+class ChartsAdmin(admin.ModelAdmin):
+    list_display = ('chart_id', 'get_music_name', 'rank', 'play_count', 'chart_date', 'type')
+    search_fields = ('music__music_name',)
+    list_filter = ('type', 'chart_date', 'created_at')
+    ordering = ('rank',)
+    list_per_page = 100
+    
+    def get_music_name(self, obj):
+        return obj.music.music_name if obj.music else '-'
+    get_music_name.short_description = '음악'
+
+
+# ===== 🤖 AI 섹션 =====
+
+@admin.register(AiInfo)
+class AiInfoAdmin(admin.ModelAdmin):
+    list_display = ('aiinfo_id', 'get_music_name', 'get_input_prompt_short', 'created_at')
+    search_fields = ('music__music_name', 'input_prompt')
+    list_filter = ('created_at',)
+    list_per_page = 50
+    
+    def get_music_name(self, obj):
+        return obj.music.music_name if obj.music else '-'
+    get_music_name.short_description = '음악'
+    
+    def get_input_prompt_short(self, obj):
+        if obj.input_prompt:
+            return obj.input_prompt[:50] + '...' if len(obj.input_prompt) > 50 else obj.input_prompt
+        return '-'
+    get_input_prompt_short.short_description = 'AI 프롬프트'

--- a/music/models.py
+++ b/music/models.py
@@ -8,11 +8,248 @@
 from django.db import models
 
 
+class AiInfo(models.Model):
+    aiinfo_id = models.AutoField(primary_key=True)
+    music = models.ForeignKey('Music', models.DO_NOTHING, blank=True, null=True)
+    input_prompt = models.CharField(max_length=500, blank=True, null=True)
+    created_at = models.DateTimeField(blank=True, null=True)
+    updated_at = models.DateTimeField(blank=True, null=True)
+    is_deleted = models.BooleanField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'ai_info'
+        verbose_name = 'AI 정보'
+        verbose_name_plural = '5️⃣ 🤖 AI - AI 정보'
+
+
+class Albums(models.Model):
+    album_id = models.BigAutoField(primary_key=True)
+    artist = models.ForeignKey('Artists', models.DO_NOTHING, blank=True, null=True)
+    album_name = models.CharField(max_length=200, blank=True, null=True)
+    album_image = models.CharField(max_length=255, blank=True, null=True)
+    created_at = models.DateTimeField(blank=True, null=True)
+    updated_at = models.DateTimeField(blank=True, null=True)
+    is_deleted = models.BooleanField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'albums'
+        verbose_name = '앨범'
+        verbose_name_plural = '2️⃣ 🎵 MUSIC - 앨범'
+
+
+class Artists(models.Model):
+    artist_id = models.BigAutoField(primary_key=True)
+    artist_name = models.CharField(max_length=100)
+    created_at = models.DateTimeField(blank=True, null=True)
+    updated_at = models.DateTimeField(blank=True, null=True)
+    is_deleted = models.BooleanField(blank=True, null=True)
+    artist_image = models.TextField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'artists'
+        verbose_name = '아티스트'
+        verbose_name_plural = '2️⃣ 🎵 MUSIC - 아티스트'
+
+
+class AuthGroup(models.Model):
+    name = models.CharField(unique=True, max_length=150)
+
+    class Meta:
+        managed = False
+        db_table = 'auth_group'
+
+
+class AuthGroupPermissions(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    group = models.ForeignKey(AuthGroup, models.DO_NOTHING)
+    permission = models.ForeignKey('AuthPermission', models.DO_NOTHING)
+
+    class Meta:
+        managed = False
+        db_table = 'auth_group_permissions'
+        unique_together = (('group', 'permission'),)
+
+
+class AuthPermission(models.Model):
+    name = models.CharField(max_length=255)
+    content_type = models.ForeignKey('DjangoContentType', models.DO_NOTHING)
+    codename = models.CharField(max_length=100)
+
+    class Meta:
+        managed = False
+        db_table = 'auth_permission'
+        unique_together = (('content_type', 'codename'),)
+
+
+class AuthUser(models.Model):
+    password = models.CharField(max_length=128)
+    last_login = models.DateTimeField(blank=True, null=True)
+    is_superuser = models.BooleanField()
+    username = models.CharField(unique=True, max_length=150)
+    first_name = models.CharField(max_length=150)
+    last_name = models.CharField(max_length=150)
+    email = models.CharField(max_length=254)
+    is_staff = models.BooleanField()
+    is_active = models.BooleanField()
+    date_joined = models.DateTimeField()
+
+    class Meta:
+        managed = False
+        db_table = 'auth_user'
+
+
+class AuthUserGroups(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    user = models.ForeignKey(AuthUser, models.DO_NOTHING)
+    group = models.ForeignKey(AuthGroup, models.DO_NOTHING)
+
+    class Meta:
+        managed = False
+        db_table = 'auth_user_groups'
+        unique_together = (('user', 'group'),)
+
+
+class AuthUserUserPermissions(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    user = models.ForeignKey(AuthUser, models.DO_NOTHING)
+    permission = models.ForeignKey(AuthPermission, models.DO_NOTHING)
+
+    class Meta:
+        managed = False
+        db_table = 'auth_user_user_permissions'
+        unique_together = (('user', 'permission'),)
+
+
+class Charts(models.Model):
+    chart_id = models.AutoField(primary_key=True)
+    music = models.ForeignKey('Music', models.DO_NOTHING, blank=True, null=True)
+    play_count = models.IntegerField(blank=True, null=True)
+    chart_date = models.DateTimeField(blank=True, null=True)
+    rank = models.IntegerField(blank=True, null=True)
+    type = models.TextField(blank=True, null=True)  # This field type is a guess.
+    created_at = models.DateTimeField(blank=True, null=True)
+    updated_at = models.DateTimeField(blank=True, null=True)
+    is_deleted = models.BooleanField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'charts'
+        verbose_name = '차트'
+        verbose_name_plural = '4️⃣ 📊 ANALYTICS - 차트'
+
+
+class DjangoAdminLog(models.Model):
+    action_time = models.DateTimeField()
+    object_id = models.TextField(blank=True, null=True)
+    object_repr = models.CharField(max_length=200)
+    action_flag = models.SmallIntegerField()
+    change_message = models.TextField()
+    content_type = models.ForeignKey('DjangoContentType', models.DO_NOTHING, blank=True, null=True)
+    user = models.ForeignKey(AuthUser, models.DO_NOTHING)
+
+    class Meta:
+        managed = False
+        db_table = 'django_admin_log'
+
+
+class DjangoCeleryResultsChordcounter(models.Model):
+    group_id = models.CharField(unique=True, max_length=255)
+    sub_tasks = models.TextField()
+    count = models.IntegerField()
+
+    class Meta:
+        managed = False
+        db_table = 'django_celery_results_chordcounter'
+
+
+class DjangoCeleryResultsGroupresult(models.Model):
+    group_id = models.CharField(unique=True, max_length=255)
+    date_created = models.DateTimeField()
+    date_done = models.DateTimeField()
+    content_type = models.CharField(max_length=128)
+    content_encoding = models.CharField(max_length=64)
+    result = models.TextField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'django_celery_results_groupresult'
+
+
+class DjangoCeleryResultsTaskresult(models.Model):
+    task_id = models.CharField(unique=True, max_length=255)
+    status = models.CharField(max_length=50)
+    content_type = models.CharField(max_length=128)
+    content_encoding = models.CharField(max_length=64)
+    result = models.TextField(blank=True, null=True)
+    date_done = models.DateTimeField()
+    traceback = models.TextField(blank=True, null=True)
+    meta = models.TextField(blank=True, null=True)
+    task_args = models.TextField(blank=True, null=True)
+    task_kwargs = models.TextField(blank=True, null=True)
+    task_name = models.CharField(max_length=255, blank=True, null=True)
+    worker = models.CharField(max_length=100, blank=True, null=True)
+    date_created = models.DateTimeField()
+    periodic_task_name = models.CharField(max_length=255, blank=True, null=True)
+    date_started = models.DateTimeField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'django_celery_results_taskresult'
+
+
+class DjangoContentType(models.Model):
+    app_label = models.CharField(max_length=100)
+    model = models.CharField(max_length=100)
+
+    class Meta:
+        managed = False
+        db_table = 'django_content_type'
+        unique_together = (('app_label', 'model'),)
+
+
+class DjangoMigrations(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    app = models.CharField(max_length=255)
+    name = models.CharField(max_length=255)
+    applied = models.DateTimeField()
+
+    class Meta:
+        managed = False
+        db_table = 'django_migrations'
+
+
+class DjangoSession(models.Model):
+    session_key = models.CharField(primary_key=True, max_length=40)
+    session_data = models.TextField()
+    expire_date = models.DateTimeField()
+
+    class Meta:
+        managed = False
+        db_table = 'django_session'
+
+
+class Genres(models.Model):
+    genre_id = models.AutoField(primary_key=True)
+    genre_name = models.CharField(max_length=50, blank=True, null=True)
+    created_at = models.DateTimeField(blank=True, null=True)
+    updated_at = models.DateTimeField(blank=True, null=True)
+    is_deleted = models.BooleanField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'genres'
+        verbose_name = '장르'
+        verbose_name_plural = '2️⃣ 🎵 MUSIC - 장르'
+
+
 class Music(models.Model):
     music_id = models.BigAutoField(primary_key=True)
     user = models.ForeignKey('Users', models.DO_NOTHING, blank=True, null=True)
-    artist = models.ForeignKey('Artists', models.DO_NOTHING, blank=True, null=True)
-    album = models.ForeignKey('Albums', models.DO_NOTHING, blank=True, null=True)
+    artist = models.ForeignKey(Artists, models.DO_NOTHING, blank=True, null=True)
+    album = models.ForeignKey(Albums, models.DO_NOTHING, blank=True, null=True)
     music_name = models.CharField(max_length=200)
     is_ai = models.BooleanField(blank=True, null=True)
     audio_url = models.CharField(max_length=200, blank=True, null=True)
@@ -29,33 +266,101 @@ class Music(models.Model):
     class Meta:
         managed = False
         db_table = 'music'
+        verbose_name = '음악'
+        verbose_name_plural = '2️⃣ 🎵 MUSIC - 음악'
 
 
-class Artists(models.Model):
-    artist_id = models.BigAutoField(primary_key=True)
-    artist_name = models.CharField(max_length=100)
-    created_at = models.DateTimeField(blank=True, null=True)
-    updated_at = models.DateTimeField(blank=True, null=True)
-    is_deleted = models.BooleanField(blank=True, null=True)
-    artist_image = models.TextField(blank=True, null=True)
-
-    class Meta:
-        managed = False
-        db_table = 'artists'
-
-
-class Albums(models.Model):
-    album_id = models.BigAutoField(primary_key=True)
-    artist = models.ForeignKey(Artists, models.DO_NOTHING, blank=True, null=True)
-    album_name = models.CharField(max_length=200, blank=True, null=True)
-    album_image = models.CharField(max_length=255, blank=True, null=True)
+class MusicLikes(models.Model):
+    like_id = models.AutoField(primary_key=True)
+    user = models.ForeignKey('Users', models.DO_NOTHING, blank=True, null=True)
+    music = models.ForeignKey(Music, models.DO_NOTHING, blank=True, null=True)
     created_at = models.DateTimeField(blank=True, null=True)
     updated_at = models.DateTimeField(blank=True, null=True)
     is_deleted = models.BooleanField(blank=True, null=True)
 
     class Meta:
         managed = False
-        db_table = 'albums'
+        db_table = 'music_likes'
+        verbose_name = '음악 좋아요'
+        verbose_name_plural = '4️⃣ 📊 ANALYTICS - 음악 좋아요'
+
+
+class MusicTags(models.Model):
+    tag = models.ForeignKey('Tags', models.DO_NOTHING)
+    music = models.OneToOneField(Music, models.DO_NOTHING, primary_key=True)  # The composite primary key (music_id, tag_id) found, that is not supported. The first column is selected.
+    created_at = models.DateTimeField()
+    updated_at = models.DateTimeField()
+    is_deleted = models.BooleanField()
+
+    class Meta:
+        managed = False
+        db_table = 'music_tags'
+        unique_together = (('music', 'tag'),)
+        verbose_name = '음악 태그'
+        verbose_name_plural = '2️⃣ 🎵 MUSIC - 음악 태그'
+
+
+class PlayLogs(models.Model):
+    play_log_id = models.AutoField(primary_key=True)
+    music = models.ForeignKey(Music, models.DO_NOTHING, blank=True, null=True)
+    user = models.ForeignKey('Users', models.DO_NOTHING, blank=True, null=True)
+    played_at = models.DateTimeField(blank=True, null=True)
+    created_at = models.DateTimeField(blank=True, null=True)
+    updated_at = models.DateTimeField(blank=True, null=True)
+    is_deleted = models.BooleanField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'play_logs'
+        verbose_name = '재생 기록'
+        verbose_name_plural = '4️⃣ 📊 ANALYTICS - 재생 기록'
+
+
+class PlaylistItems(models.Model):
+    item_id = models.AutoField(primary_key=True)
+    music = models.ForeignKey(Music, models.DO_NOTHING, blank=True, null=True)
+    playlist = models.ForeignKey('Playlists', models.DO_NOTHING, blank=True, null=True)
+    order = models.IntegerField(blank=True, null=True)
+    created_at = models.DateTimeField(blank=True, null=True)
+    updated_at = models.DateTimeField(blank=True, null=True)
+    is_deleted = models.BooleanField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'playlist_items'
+        verbose_name = '플레이리스트 항목'
+        verbose_name_plural = '3️⃣ 📝 PLAYLIST - 플레이리스트 항목'
+
+
+class PlaylistLikes(models.Model):
+    like_id = models.AutoField(primary_key=True)
+    user = models.ForeignKey('Users', models.DO_NOTHING, blank=True, null=True)
+    playlist = models.ForeignKey('Playlists', models.DO_NOTHING, blank=True, null=True)
+    created_at = models.DateTimeField(blank=True, null=True)
+    updated_at = models.DateTimeField(blank=True, null=True)
+    is_deleted = models.BooleanField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'playlist_likes'
+        verbose_name = '플레이리스트 좋아요'
+        verbose_name_plural = '3️⃣ 📝 PLAYLIST - 플레이리스트 좋아요'
+
+
+class Playlists(models.Model):
+    playlist_id = models.AutoField(primary_key=True)
+    user = models.ForeignKey('Users', models.DO_NOTHING, blank=True, null=True)
+    title = models.CharField(max_length=100, blank=True, null=True)
+    visibility = models.TextField(blank=True, null=True)  # This field type is a guess.
+    created_at = models.DateTimeField(blank=True, null=True)
+    updated_at = models.DateTimeField(blank=True, null=True)
+    is_deleted = models.BooleanField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'playlists'
+        verbose_name = '플레이리스트'
+        verbose_name_plural = '3️⃣ 📝 PLAYLIST - 플레이리스트'
 
 
 class Tags(models.Model):
@@ -68,25 +373,14 @@ class Tags(models.Model):
     class Meta:
         managed = False
         db_table = 'tags'
-
-
-class MusicTags(models.Model):
-    tag = models.ForeignKey(Tags, models.DO_NOTHING)
-    music = models.OneToOneField(Music, models.DO_NOTHING, primary_key=True)  # The composite primary key (music_id, tag_id) found, that is not supported. The first column is selected.
-    created_at = models.DateTimeField()
-    updated_at = models.DateTimeField()
-    is_deleted = models.BooleanField()
-
-    class Meta:
-        managed = False
-        db_table = 'music_tags'
-        unique_together = (('music', 'tag'),)
+        verbose_name = '태그'
+        verbose_name_plural = '2️⃣ 🎵 MUSIC - 태그'
 
 
 class Users(models.Model):
     user_id = models.BigAutoField(primary_key=True)
     email = models.CharField(max_length=100)
-    password = models.IntegerField(blank=True, null=True)
+    password = models.CharField(max_length=255, blank=True, null=True)
     nickname = models.CharField(max_length=50, blank=True, null=True)
     created_at = models.DateTimeField(blank=True, null=True)
     updated_at = models.DateTimeField(blank=True, null=True)
@@ -95,3 +389,20 @@ class Users(models.Model):
     class Meta:
         managed = False
         db_table = 'users'
+        verbose_name = '사용자'
+        verbose_name_plural = '1️⃣ 👤 USER - 사용자'
+
+
+class UsersGenre(models.Model):
+    user = models.OneToOneField(Users, models.DO_NOTHING, primary_key=True)  # The composite primary key (user_id, genre_id) found, that is not supported. The first column is selected.
+    genre = models.ForeignKey(Genres, models.DO_NOTHING)
+    created_at = models.DateTimeField(blank=True, null=True)
+    updated_at = models.DateTimeField(blank=True, null=True)
+    is_deleted = models.BooleanField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'users_genre'
+        unique_together = (('user', 'genre'),)
+        verbose_name = '사용자 선호 장르'
+        verbose_name_plural = '1️⃣ 👤 USER - 사용자 선호 장르'


### PR DESCRIPTION
- Music, Artists, Albums 등 모든 모델에 verbose_name_plural 추가
- 카테고리별 분류: USER, MUSIC, PLAYLIST, ANALYTICS, AI
- Admin 페이지에서 섹션별로 정렬된 표시 구현
- 각 모델의 Admin 설정 최적화 (list_display, search_fields, filters)