### PR TITLE
feat:회원가입 시 users DB 에러해결

### DIFF
--- a/music/serializers.py
+++ b/music/serializers.py
@@ -4,6 +4,7 @@
 """
 from rest_framework import serializers
 from django.contrib.auth.hashers import make_password
+from django.utils import timezone  # 타임스탬프 자동 설정을 위해 추가
 from .models import Users
 
 
@@ -17,7 +18,16 @@ class UserRegisterSerializer(serializers.ModelSerializer):
     
     def create(self, validated_data):
         """비밀번호 해싱 후 사용자 생성"""
+        # 비밀번호를 해시값으로 변환 (보안)
         validated_data['password'] = make_password(validated_data['password'])
+        
+        # 타임스탬프 및 삭제 플래그 자동 설정
+        # Users 모델이 managed=False로 설정되어 있어 auto_now_add/auto_now가 작동하지 않음
+        # 따라서 수동으로 값을 설정해야 함
+        validated_data['created_at'] = timezone.now()  # 생성 시간
+        validated_data['updated_at'] = timezone.now()  # 수정 시간 (생성 시에는 created_at과 동일)
+        validated_data['is_deleted'] = False  # 삭제 플래그 (기본값: False)
+        
         return Users.objects.create(**validated_data)
 
 


### PR DESCRIPTION
# 문제
회원가입 시 created_at, updated_at, is_deleted가 NULL로 저장됨.

# 원인
1. Users 모델이 managed = False로 설정되어 있음
 - Django가 테이블을 관리하지 않음 (기존 DB 역공학)
2. 필드에 자동 설정 옵션이 없음
 - auto_now_add=True, auto_now=True, default=False 없음
3. Serializer에서 값을 설정하지 않음
- create() 메서드에서 해당 필드 값을 명시적으로 설정하지 않음

# 해결
-> Serializer에서 create() 시 수동으로 값 설정해서 해결함
