### PR TITLE
feat: 개별 컨테이너 수치확인

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -149,7 +149,31 @@ services:
         limits:
           memory: 150M
 
-  # 8. Grafana Agent (메트릭 전송 - 완벽 설정)
+  # 8. cAdvisor (컨테이너 메트릭 수집)
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.47.0
+    container_name: cadvisor
+    privileged: true
+    devices:
+      - /dev/kmsg
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    ports:
+      - "8080:8080"
+    networks:
+      - ubuntu_gitops-network
+    restart: unless-stopped
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 200M
+
+  # 9. Grafana Agent (메트릭 전송 - 완벽 설정)
   grafana-agent:
     image: grafana/agent:latest
     container_name: grafana-agent

--- a/monitoring/agent-cloud.yml
+++ b/monitoring/agent-cloud.yml
@@ -44,6 +44,14 @@ metrics:
                 instance: 'backend-server'
                 service: 'django-backend'
           metrics_path: '/metrics'
+        
+        # 3. cAdvisor (컨테이너 메트릭)
+        - job_name: 'cadvisor'
+          static_configs:
+            - targets: ['cadvisor:8080']
+              labels:
+                instance: 'backend-server'
+                service: 'cadvisor'
 
 # ===== 핵심: Node Exporter 통합 (서버 메트릭) =====
 integrations:
@@ -78,11 +86,3 @@ integrations:
     # 파일시스템 마운트 포인트 필터 (불필요한 항목 제외)
     filesystem_mount_points_exclude: "^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)"
     filesystem_fs_types_exclude: "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"
-
-  # cAdvisor 통합 (Docker 컨테이너 메트릭)
-  cadvisor:
-    enabled: true
-    instance: 'backend-server'
-    docker_only: true
-    # Docker 소켓 경로
-    docker: unix:///var/run/docker.sock


### PR DESCRIPTION
## 개요
개별 Docker 컨테이너 메트릭 수집을 위한 cAdvisor 컨테이너 추가

## 변경사항

### 1. cAdvisor 독립 컨테이너 추가 (docker-compose.prod.yml)

**문제점**
- Grafana Agent의 cAdvisor integration이 개별 컨테이너 메트릭 수집 실패
- 컨테이너별 CPU, 메모리, 네트워크 사용량 확인 불가

**해결**
- 독립적인 cAdvisor 컨테이너 추가
- 모든 Docker 컨테이너의 리소스 사용량 수집
- Grafana Agent가 cAdvisor를 스크랩하도록 설정

### 2. Grafana Agent 설정 개선 (monitoring/agent-cloud.yml)

**변경**
- cAdvisor integration 제거
- cAdvisor scrape_config 추가 (cadvisor:8080)
- Integration prometheus_remote_write 설정 추가 (Node Exporter 메트릭 전송)

### 3. Backend 컨테이너 이름 고정 (docker-compose.prod.yml)

**변경**
- backend 서비스에 `container_name: backend` 추가
- Grafana Agent가 일관된 이름으로 Django 메트릭 수집 가능

## 수정 파일
- `docker-compose.prod.yml`
- `monitoring/agent-cloud.yml`

## 테스트 방법
1. 배포 후 Grafana Cloud Explore에서 쿼리
   - `container_cpu_usage_seconds_total{id!="/"}`
   - `container_memory_usage_bytes{name=~".+"}`
2. "Docker and system monitoring" 대시보드에서 컨테이너별 메트릭 확인