### PR TITLE
feat:music_id로 태그 불러오기

### DIFF
--- a/music/urls.py
+++ b/music/urls.py
@@ -14,6 +14,7 @@ from .views import (
     MusicSearchView,
     AiMusicSearchView,
     MusicDetailView as iTunesMusicDetailView,  # iTunes 기반 상세 조회 (기존)
+    MusicTagsView,  # 음악 태그 조회
     ArtistDetailView,
     ArtistTracksView,
     ArtistAlbumsView,
@@ -90,6 +91,10 @@ urlpatterns = [
     # GET /api/v1/tracks/{music_id}/play - 재생 정보 조회 (로그 저장 안 함)
     # POST /api/v1/tracks/{music_id}/play - 재생 로그 기록
     path('tracks/<int:music_id>/play', PlayLogView.as_view(), name='music-play'),
+    
+    # 음악 태그 조회
+    # GET /api/v1/tracks/{music_id}/tags - music_id로 태그 목록 조회
+    path('tracks/<int:music_id>/tags', MusicTagsView.as_view(), name='music-tags'),
 
     # 인기 아티스트 목록 조회
     # GET /api/v1/artists/popular?limit=7

--- a/music/views/__init__.py
+++ b/music/views/__init__.py
@@ -28,7 +28,7 @@ from .likes import MusicLikeView, UserLikedMusicListView, AlbumLikeView, UserLik
 from .search import MusicSearchView, AiMusicSearchView
 
 # 음악 상세 관련 Views
-from .music import MusicDetailView, MusicPlayView
+from .music import MusicDetailView, MusicPlayView, MusicTagsView
 
 # 아티스트 관련 Views
 from .artists import ArtistDetailView, ArtistTracksView, ArtistAlbumsView, AlbumDetailView, PopularArtistsView
@@ -95,6 +95,7 @@ __all__ = [
     # music
     'MusicDetailView',
     'MusicPlayView',
+    'MusicTagsView',
     # artists
     'ArtistDetailView',
     'ArtistTracksView',


### PR DESCRIPTION
## Summary

음악 ID로 태그를 조회할 수 있는 새로운 API 엔드포인트를 추가했습니다.

- `GET /api/v1/tracks/{music_id}/tags` 엔드포인트 구현
- 음악 상세 페이지에서 태그 정보를 불러올 수 있도록 개선

## Changes

### 1. 새로운 API 엔드포인트 추가
- **엔드포인트**: `GET /api/v1/tracks/{music_id}/tags`
- **기능**: music_id를 통해 해당 음악에 연결된 태그 목록 조회
- **권한**: 인증 불필요 (AllowAny)

### 2. 구현 세부사항

#### `music/views/music.py`
- `MusicTagsView` 클래스 추가
  - music_id로 음악 존재 여부 확인
  - 삭제되지 않은 태그만 필터링하여 반환
  - OpenAPI 스키마 문서화 포함

#### `music/urls.py`
- 새로운 URL 패턴 추가: `tracks/<int:music_id>/tags`

#### `music/views/__init__.py`
- `MusicTagsView` import 및 export 추가

## API Specification

### Request
GET /api/v1/tracks/{music_id}/tags
