### PR TITLE
Add monitoring stack: Prometheus, Loki, and Promtail

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -135,16 +135,36 @@ services:
 
   # ===== 모니터링 스택 =====
 
-  # 7. Promtail (로그 전송)
+  # 7. Loki (로그 수집 및 저장)
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    ports:
+      - "3100:3100"  # Loki API
+    volumes:
+      - ./monitoring/loki.yml:/etc/loki/local-config.yaml:ro
+      - loki_data:/tmp/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - ubuntu_gitops-network
+    restart: unless-stopped
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+
+  # 8. Promtail (로그 전송)
   promtail:
     image: grafana/promtail:latest
+    container_name: promtail
     volumes:
-      - ./monitoring/promtail-cloud.yml:/etc/promtail/config.yml:ro
+      - ./monitoring/promtail.yml:/etc/promtail/config.yml:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    command: -config.file=/etc/promtail/config.yml -config.expand-env=true
-    env_file:
-      - .env.production
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      - loki
     networks:
       - ubuntu_gitops-network
     restart: unless-stopped
@@ -154,7 +174,7 @@ services:
         limits:
           memory: 150M
 
-  # 8. cAdvisor (컨테이너 메트릭 수집)
+  # 9. cAdvisor (컨테이너 메트릭 수집)
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:v0.47.0
     container_name: cadvisor
@@ -178,7 +198,7 @@ services:
         limits:
           memory: 200M
 
-  # 9. Grafana Agent (메트릭 전송 - 완벽 설정)
+  # 10. Grafana Agent (메트릭 전송 - 완벽 설정)
   grafana-agent:
     image: grafana/agent:latest
     container_name: grafana-agent
@@ -225,7 +245,7 @@ services:
         reservations:
           memory: 128M
 
-  # 10. Prometheus (메트릭 수집 및 저장)
+  # 11. Prometheus (메트릭 수집 및 저장)
   prometheus:
     image: prom/prometheus:latest
     container_name: prometheus
@@ -247,7 +267,7 @@ services:
         limits:
           memory: 512M
 
-  # 11. Grafana - 시각화 대시보드
+  # 12. Grafana - 시각화 대시보드
   grafana:
     image: grafana/grafana:latest
     container_name: grafana
@@ -263,6 +283,7 @@ services:
       - GF_USERS_ALLOW_SIGN_UP=false
     depends_on:
       - prometheus
+      - loki
     networks:
       - ubuntu_gitops-network
     restart: unless-stopped
@@ -282,4 +303,6 @@ volumes:
   prometheus_data:  # Prometheus 메트릭 데이터
     driver: local
   grafana_data:  # Grafana 대시보드 및 설정
+    driver: local
+  loki_data:  # Loki 로그 데이터
     driver: local

--- a/monitoring/loki.yml
+++ b/monitoring/loki.yml
@@ -1,0 +1,50 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/analytics/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# If you would like to disable reporting, uncomment the following lines:
+#analytics:
+#  reporting_enabled: false

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,23 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  # Prometheus 자체 모니터링
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  # RabbitMQ 메트릭 수집
+  - job_name: 'rabbitmq'
+    static_configs:
+      - targets: ['rabbitmq:15692']
+        labels:
+          service: 'rabbitmq'
+
+  # Django 애플리케이션 메트릭 (django-prometheus 사용 시)
+  - job_name: 'django'
+    static_configs:
+      - targets: ['backend:8000']
+        labels:
+          service: 'django'

--- a/monitoring/promtail.yml
+++ b/monitoring/promtail.yml
@@ -1,0 +1,22 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  # Docker 컨테이너 로그 수집
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: 'container'
+      - source_labels: ['__meta_docker_container_log_stream']
+        target_label: 'stream'


### PR DESCRIPTION
- Add prometheus.yml with backend:8000 target (fixed from web:8000)
- Add loki.yml for local log aggregation
- Add promtail.yml for Docker container log collection
- Update docker-compose.prod.yml to include Loki service
- Update Promtail to use local Loki instead of Grafana Cloud
- Add loki_data volume for log persistence
- Update Grafana dependencies to include Loki