### PR TITLE
feat: 태그로 음악 검색 API 추가

### DIFF
--- a/music/serializers/__init__.py
+++ b/music/serializers/__init__.py
@@ -33,6 +33,7 @@ from .music import (
 from .search import (
     iTunesSearchResultSerializer,
     AiMusicSearchResultSerializer,
+    TagMusicSearchSerializer,
 )
 
 # 인증 관련 Serializers
@@ -107,6 +108,7 @@ __all__ = [
     # search
     'iTunesSearchResultSerializer',
     'AiMusicSearchResultSerializer',
+    'TagMusicSearchSerializer',
     # auth
     'UserRegisterSerializer',
     'UserLoginSerializer',

--- a/music/serializers/search.py
+++ b/music/serializers/search.py
@@ -53,3 +53,18 @@ class AiMusicSearchResultSerializer(serializers.Serializer):
             seconds = obj.duration % 60
             return f"{minutes}:{seconds:02d}"
         return None
+
+
+class TagMusicSearchSerializer(serializers.Serializer):
+    """
+    태그로 음악 검색 결과용 Serializer
+    
+    - 특정 태그를 가진 모든 음악 반환
+    - music_id, album_name, artist_name, 앨범 이미지 정보 포함
+    """
+    music_id = serializers.IntegerField()
+    album_name = serializers.CharField(allow_null=True)
+    artist_name = serializers.CharField(allow_null=True)
+    image_large_square = serializers.CharField(allow_null=True)  # 360x360 사각형 이미지
+    image_square = serializers.CharField(allow_null=True)  # 220x220 사각형 이미지
+    album_image = serializers.CharField(allow_null=True)  # 원본 앨범 이미지

--- a/music/urls.py
+++ b/music/urls.py
@@ -14,6 +14,7 @@ from .views import (
     UserLikedMusicListView,
     MusicSearchView,
     AiMusicSearchView,
+    TagMusicSearchView,
     MusicDetailView as iTunesMusicDetailView,  # iTunes 기반 상세 조회 (기존)
     MusicTagsView,  # 음악 태그 조회
     MusicTagGraphView, # 음악 태그 그래프 조회
@@ -94,6 +95,10 @@ urlpatterns = [
     # AI 음악 검색 (AI 음악 전용)
     # GET /api/music/search-ai/?q={검색어}
     path('search-ai/', AiMusicSearchView.as_view(), name='ai-music-search'),
+    
+    # 태그로 음악 검색
+    # GET /api/v1/search/tags?tag={tag_key}&page={num}&page_size={num}
+    path('search/tags', TagMusicSearchView.as_view(), name='tag-music-search'),
     
     # OpenSearch 기반 검색
     # GET /api/v1/search/opensearch?q={검색어}&sort_by={정렬}&exclude_ai={bool}

--- a/music/views/__init__.py
+++ b/music/views/__init__.py
@@ -25,7 +25,7 @@ from .auth import (
 from .likes import MusicLikeView, TrackLikesCountView, UserLikedMusicListView, AlbumLikeView, UserLikedAlbumsView
 
 # 검색 관련 Views
-from .search import MusicSearchView, AiMusicSearchView
+from .search import MusicSearchView, AiMusicSearchView, TagMusicSearchView
 
 # 음악 상세 관련 Views
 from .music import MusicDetailView, MusicPlayView, MusicTagsView, MusicTagGraphView
@@ -96,6 +96,7 @@ __all__ = [
     # search
     'MusicSearchView',
     'AiMusicSearchView',
+    'TagMusicSearchView',
     # music
     'MusicDetailView',
     'MusicPlayView',


### PR DESCRIPTION
- 특정 태그를 가진 모든 음악 검색 기능 추가
- 최대 3개 태그까지 쉼표로 구분하여 검색 가능 (OR 조건)
- 중복 결과 자동 제거
- music_id, album_name, artist_name, 앨범 이미지 정보 반환
- GET /api/v1/search/tags?tag={tag_key} 엔드포인트 추가