### PR TITLE
fix: Correct MusicTags related_name in OpenSearch sync

### DIFF
--- a/music/management/commands/opensearch_setup.py
+++ b/music/management/commands/opensearch_setup.py
@@ -124,7 +124,7 @@ class Command(BaseCommand):
         # DB에서 모든 음악 조회
         musics = Music.objects.select_related(
             'artist', 'album'
-        ).prefetch_related('music_tags__tag')
+        ).prefetch_related('musictags_set__tag')
         
         total_count = musics.count()
         self.stdout.write(f'총 {total_count}개의 음악을 동기화합니다...')
@@ -132,7 +132,7 @@ class Command(BaseCommand):
         music_list = []
         for music in musics:
             # 태그 추출
-            tags = [mt.tag.tag_key for mt in music.music_tags.all() if mt.tag]
+            tags = [mt.tag.tag_key for mt in music.musictags_set.all() if mt.tag]
             
             music_data = {
                 'music_id': music.music_id,

--- a/music/views/opensearch_search.py
+++ b/music/views/opensearch_search.py
@@ -307,12 +307,12 @@ class OpenSearchSyncView(APIView):
             # DB에서 모든 음악 조회
             musics = Music.objects.select_related(
                 'artist', 'album'
-            ).prefetch_related('music_tags__tag')
+            ).prefetch_related('musictags_set__tag')
             
             music_list = []
             for music in musics:
                 # 태그 추출
-                tags = [mt.tag.tag_key for mt in music.music_tags.all() if mt.tag]
+                tags = [mt.tag.tag_key for mt in music.musictags_set.all() if mt.tag]
                 
                 music_data = {
                     'music_id': music.music_id,


### PR DESCRIPTION
## 🔧 수정 내용
Django의 related_name 문제를 해결했습니다.
### 문제 원인:
Music 모델에서 MusicTags로의 역참조 관계 이름이 명시되지 않아서 Django가 자동으로 musictags_set을 사용하는데, 코드에서는 music_tags로 접근하려고 했습니다.