### PR TITLE
fix: OpenSearch 검색 결과 개선: itunes_id 대신 music_id 사용

### DIFF
--- a/music/views/opensearch_search.py
+++ b/music/views/opensearch_search.py
@@ -182,27 +182,27 @@ class OpenSearchMusicSearchView(APIView):
         # DB에서 audio_url과 album_image 조회
         from ..models import Music
         
-        itunes_ids = [hit.get('itunes_id') for hit in search_results['hits'] if hit.get('itunes_id')]
+        music_ids = [hit.get('music_id') for hit in search_results['hits'] if hit.get('music_id')]
         music_dict = {}
         
-        if itunes_ids:
+        if music_ids:
             # DB에서 한 번에 조회 (select_related로 album도 JOIN)
             musics = Music.objects.filter(
-                itunes_id__in=itunes_ids
+                music_id__in=music_ids
             ).select_related('album').only(
-                'itunes_id', 'audio_url', 'album_id', 'album__album_image'
+                'music_id', 'audio_url', 'album_id', 'album__album_image'
             )
-            # itunes_id를 키로 하는 딕셔너리 생성 (빠른 접근)
-            music_dict = {m.itunes_id: m for m in musics}
+            # music_id를 키로 하는 딕셔너리 생성 (빠른 접근)
+            music_dict = {m.music_id: m for m in musics}
         
         # 결과를 iTunes 검색 결과 형식으로 변환
         results = []
         for hit in search_results['hits']:
-            itunes_id = hit.get('itunes_id')
-            music_in_db = music_dict.get(itunes_id)
+            music_id = hit.get('music_id')
+            music_in_db = music_dict.get(music_id)
             
             results.append({
-                'itunes_id': itunes_id,
+                'music_id': music_id,
                 'music_name': hit.get('music_name', ''),
                 'artist_name': hit.get('artist_name', ''),
                 'artist_id': hit.get('artist_id'),


### PR DESCRIPTION
### 📝 Summary
- OpenSearch 검색 결과에서 `itunes_id` 대신 `music_id`를 기본 식별자로 사용
- 아티스트 동의어 검색 기능 추가 (IU ↔ 아이유)
- 검색 결과에 `audio_url`, `album_image` 자동 보강
- OpenSearch 타임아웃 증가 및 안정성 개선

### 🎯 주요 변경사항

#### 1. music_id 기반 검색 결과 반환
**문제**: 
- 일부 음악(AI 생성곡, 사용자 업로드 곡)은 `itunes_id`가 null
- `itunes_id` 기반 DB 조회 시 해당 곡들의 `audio_url`, `album_image`를 가져오지 못함

**해결**:
- 모든 음악이 필수로 가지고 있는 `music_id`를 기본 식별자로 사용
- DB 조회 시 `music_id` 기준으로 변경
- 검색 결과 응답에 `music_id` 포함

**변경 전**:
itunes_ids = [hit.get('itunes_id') for hit in search_results['hits']]
musics = Music.objects.filter(itunes_id__in=itunes_ids)
results.append({'itunes_id': itunes_id, ...})
