### PR TITLE
feat: 태그 검색 API 응답에 music_name 필드 추가

### DIFF
--- a/music/serializers/search.py
+++ b/music/serializers/search.py
@@ -60,9 +60,10 @@ class TagMusicSearchSerializer(serializers.Serializer):
     태그로 음악 검색 결과용 Serializer
     
     - 특정 태그를 가진 모든 음악 반환
-    - music_id, album_name, artist_name, 앨범 이미지 정보, 태그 점수 포함
+    - music_id, music_name, album_name, artist_name, 앨범 이미지 정보, 태그 점수 포함
     """
     music_id = serializers.IntegerField()
+    music_name = serializers.CharField()
     album_name = serializers.CharField(allow_null=True)
     artist_name = serializers.CharField(allow_null=True)
     image_large_square = serializers.CharField(allow_null=True)  # 360x360 사각형 이미지

--- a/music/views/search.py
+++ b/music/views/search.py
@@ -471,6 +471,7 @@ class TagMusicSearchView(APIView):
         
         **반환 정보:**
         - music_id: 음악 ID
+        - music_name: 음악 제목
         - album_name: 앨범명
         - artist_name: 아티스트명
         - image_large_square: 360x360 사각형 이미지
@@ -612,6 +613,7 @@ class TagMusicSearchView(APIView):
             
             results.append({
                 'music_id': music.music_id,
+                'music_name': music.music_name,
                 'album_name': album.album_name if album else None,
                 'artist_name': artist.artist_name if artist else None,
                 'image_large_square': album.image_large_square if album else None,


### PR DESCRIPTION
- TagMusicSearchSerializer에 music_name 필드 추가
- 태그 검색 결과에 음악 제목(music_name) 포함