### PR TITLE
fix: 차트 집계 및 조회에서 삭제된 음악 제외

### DIFF
--- a/music/tasks/charts.py
+++ b/music/tasks/charts.py
@@ -32,7 +32,8 @@ def update_realtime_chart():
             results = PlayLogs.objects.filter(
                 played_at__gte=start_time,
                 played_at__lt=now,
-                is_deleted=False
+                is_deleted=False,
+                music__is_deleted=False  # 삭제된 음악 제외
             ).values('music_id').annotate(
                 play_count=Count('play_log_id')
             ).order_by('-play_count')[:100]
@@ -87,7 +88,8 @@ def update_daily_chart():
             results = PlayLogs.objects.filter(
                 played_at__gte=yesterday_start,
                 played_at__lt=yesterday_end,
-                is_deleted=False
+                is_deleted=False,
+                music__is_deleted=False  # 삭제된 음악 제외
             ).values('music_id').annotate(
                 play_count=Count('play_log_id')
             ).order_by('-play_count')[:100]

--- a/music/views/charts.py
+++ b/music/views/charts.py
@@ -124,7 +124,10 @@ class ChartView(APIView):
         
         # 3. 현재 차트 조회
         # DB가 timestamp(timezone 없음)이므로 날짜+시간 문자열로 비교
-        chart_items = Charts.objects.filter(type=type).extra(
+        chart_items = Charts.objects.filter(
+            type=type,
+            music__is_deleted=False  # 삭제된 음악 제외
+        ).extra(
             where=["chart_date::text = %s::text"],
             params=[str(latest_chart.chart_date)]
         ).select_related(
@@ -143,11 +146,14 @@ class ChartView(APIView):
         previous_ranks = {}
         if previous_chart:
             # 이전 차트의 순위 정보를 {music_id: rank} 딕셔너리로 구성
-            previous_items = Charts.objects.filter(type=type).extra(
+            previous_items = Charts.objects.filter(
+                type=type,
+                music__is_deleted=False  # 삭제된 음악 제외
+            ).extra(
                 where=["chart_date::text = %s::text"],
                 params=[str(previous_chart.chart_date)]
             ).values('music_id', 'rank')
-            
+
             previous_ranks = {item['music_id']: item['rank'] for item in previous_items}
         
         # 5. 각 차트 항목에 rank_change 추가


### PR DESCRIPTION
- 실시간 차트 집계에서 is_deleted된 음악 제외
- 일일 차트 집계에서 is_deleted된 음악 제외
- 차트 조회 API에서 is_deleted된 음악 제외
- 이전 차트 조회 시에도 is_deleted 필터 적용