### PR TITLE
feat:검색결과 최적화 및 앨범 사진오류 해결

### DIFF
--- a/music/services/opensearch.py
+++ b/music/services/opensearch.py
@@ -432,6 +432,15 @@ class OpenSearchService:
             must_clauses.append({
                 "bool": {
                     "should": [
+                        # 0. 아티스트명 정확 일치 (최우선순위)
+                        {
+                            "term": {
+                                "artist_name.keyword": {
+                                    "value": query,
+                                    "boost": 100.0  # 정확히 일치하는 아티스트는 100배 부스트
+                                }
+                            }
+                        },
                         # 1. 정확한 매칭 (최우선, fuzziness 없음)
                         {
                             "multi_match": {

--- a/music/views/opensearch_search.py
+++ b/music/views/opensearch_search.py
@@ -190,9 +190,7 @@ class OpenSearchMusicSearchView(APIView):
             # DB에서 한 번에 조회 (select_related로 album도 JOIN)
             musics = Music.objects.filter(
                 music_id__in=music_ids
-            ).select_related('album').only(
-                'music_id', 'audio_url', 'album_id', 'album__album_image'
-            )
+            ).select_related('album')
             # music_id를 키로 하는 딕셔너리 생성 (빠른 접근)
             music_dict = {m.music_id: m for m in musics}
         


### PR DESCRIPTION
### 1. 아티스트 검색 순위 개선 
- **파일**: `music/services/opensearch.py`
- **문제**: 아티스트 검색 시 피처링 곡이 본인 곡보다 먼저 노출
- **해결**: `artist_name.keyword` 정확 일치 조건 추가 (boost: 100x)
- **효과**: 
  - Before: "지코 (Feat. 아이유)" → 점수 25
  - After: "아이유 - 밤편지" → 점수 123 (100 + 23) 

### 2. 앨범 이미지 표시 버그 수정 
- **파일**: `music/views/opensearch_search.py`
- **문제**: 검색 결과에서 모든 곡이 같은 앨범 이미지 표시
- **원인**: `.only()` 메서드 사용으로 Album 객체 불완전 로드
- **해결**: `.only()` 제거하여 전체 객체 로드