### PR TITLE
fix: Traefik CORS 설정에 Vercel 프론트엔드 도메인 추가

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,7 +28,7 @@ services:
 
       # ===== CORS 미들웨어 추가 =====
       - "traefik.http.middlewares.backend-cors.headers.accesscontrolallowmethods=GET,POST,PUT,DELETE,PATCH,OPTIONS"
-      - "traefik.http.middlewares.backend-cors.headers.accesscontrolalloworiginlist=http://localhost:4173,http://localhost:5173,https://your-frontend-domain.com"
+      - "traefik.http.middlewares.backend-cors.headers.accesscontrolalloworiginlist=http://localhost:4173,http://localhost:5173,http://localhost:3000,https://frontend-eosin-seven-18.vercel.app"
       - "traefik.http.middlewares.backend-cors.headers.accesscontrolallowcredentials=true"
       - "traefik.http.middlewares.backend-cors.headers.accesscontrolallowheaders=Content-Type,Authorization,Accept,Accept-Encoding,X-Requested-With"
       - "traefik.http.middlewares.backend-cors.headers.accesscontrolmaxage=86400"


### PR DESCRIPTION
- accesscontrolalloworiginlist에 https://frontend-eosin-seven-18.vercel.app 추가
- localhost:3000도 추가하여 로컬 개발 환경 지원
- CORS 에러 해결을 위한 리버스 프록시 설정 수정