### PR TITLE
fix: OpenSearch 인덱싱 시 is_deleted=True 데이터 제외

### DIFF
--- a/music/management/commands/opensearch_setup.py
+++ b/music/management/commands/opensearch_setup.py
@@ -120,20 +120,22 @@ class Command(BaseCommand):
     def _sync_data(self):
         """DB 데이터를 OpenSearch에 동기화"""
         self.stdout.write('DB 데이터를 OpenSearch에 동기화합니다...')
-        
-        # DB에서 모든 음악 조회
-        musics = Music.objects.select_related(
+
+        # DB에서 삭제되지 않은 음악만 조회
+        musics = Music.objects.filter(
+            is_deleted=False
+        ).select_related(
             'artist', 'album'
         ).prefetch_related('musictags_set__tag')
-        
+
         total_count = musics.count()
         self.stdout.write(f'총 {total_count}개의 음악을 동기화합니다...')
-        
+
         music_list = []
         for music in musics:
             # 태그 추출
             tags = [mt.tag.tag_key for mt in music.musictags_set.all() if mt.tag]
-            
+
             music_data = {
                 'music_id': music.music_id,
                 'itunes_id': music.itunes_id,

--- a/music/views/opensearch_search.py
+++ b/music/views/opensearch_search.py
@@ -340,16 +340,18 @@ class OpenSearchSyncView(APIView):
         from ..models import Music
         
         try:
-            # DB에서 모든 음악 조회
-            musics = Music.objects.select_related(
+            # DB에서 삭제되지 않은 음악만 조회
+            musics = Music.objects.filter(
+                is_deleted=False
+            ).select_related(
                 'artist', 'album'
             ).prefetch_related('musictags_set__tag')
-            
+
             music_list = []
             for music in musics:
                 # 태그 추출
                 tags = [mt.tag.tag_key for mt in music.musictags_set.all() if mt.tag]
-                
+
                 music_data = {
                     'music_id': music.music_id,
                     'itunes_id': music.itunes_id,


### PR DESCRIPTION
- Music.objects.filter(is_deleted=False)로 삭제된 음악 데이터 필터링
- opensearch_setup 관리 명령어 및 API 동기화 엔드포인트에 적용
- 삭제된 데이터가 검색 결과에 나타나지 않도록 개선