### PR TITLE
feat: node-exporter, celery-exporter 추가 및 Prometheus scrape 설정

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -198,7 +198,51 @@ services:
         limits:
           memory: 200M
 
-  # 10. Grafana Agent (메트릭 전송 - 완벽 설정)
+  # 10. Node Exporter (호스트 시스템 메트릭)
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: node-exporter
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--path.rootfs=/rootfs'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    ports:
+      - "9100:9100"
+    networks:
+      - ubuntu_gitops-network
+    restart: unless-stopped
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+
+  # 11. Celery Exporter (Celery 메트릭)
+  celery-exporter:
+    image: danihodovic/celery-exporter:latest
+    container_name: celery-exporter
+    environment:
+      - CE_BROKER_URL=amqp://guest:guest@rabbitmq:5672//
+    ports:
+      - "9808:9808"
+    depends_on:
+      - rabbitmq
+      - celery
+    networks:
+      - ubuntu_gitops-network
+    restart: unless-stopped
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+
+  # 12. Grafana Agent (메트릭 전송 - 완벽 설정)
   grafana-agent:
     image: grafana/agent:latest
     container_name: grafana-agent

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -21,3 +21,24 @@ scrape_configs:
       - targets: ['backend:8000']
         labels:
           service: 'django'
+
+  # cAdvisor - 컨테이너 메트릭
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['cadvisor:8080']
+        labels:
+          service: 'cadvisor'
+
+  # Node Exporter - 호스트 시스템 메트릭
+  - job_name: 'node-exporter'
+    static_configs:
+      - targets: ['node-exporter:9100']
+        labels:
+          service: 'node-exporter'
+
+  # Celery Exporter - Celery 워커 메트릭
+  - job_name: 'celery-exporter'
+    static_configs:
+      - targets: ['celery-exporter:9808']
+        labels:
+          service: 'celery-exporter'


### PR DESCRIPTION
- docker-compose.prod.yml에 node-exporter(9100), celery-exporter(9808) 서비스 추가
- prometheus.yml에 cadvisor, node-exporter, celery-exporter scrape config 추가